### PR TITLE
:art: change using docker image alpine to ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: alpine:3.15
+      - image: ruby:3.0.2
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference


### PR DESCRIPTION
## 概要
circleCIで利用するイメージがサンプルのままのalpineだった
minitestを実行できるように公式のrubyイメージを利用するよう変更
バージョンは現時点で最新の3系を利用

## 動作確認
- [x] CIが通る